### PR TITLE
.DS-Store should be ignored, for Mac OS X development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 ./.idea
+
+# for Mac OS X
+.DS_Store


### PR DESCRIPTION
Added .DS_Store to .gitinore file.
