### PR TITLE
use state & action to handle `pending` state for universal rendering

### DIFF
--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -107,11 +107,22 @@ export function doPreventedNavigation(){
 
 
 //  ************************* UNIVERSAL HELPERS *************************************
-export function universalSetPeniding(val, done){
+
+export function universalResetPending(){
     return {
-        type:'UNIVERSAL_SET_PENDING',
-        val,
-        done
+        type:'UNIVERSAL_RESET_PENDING'
+    }
+}
+
+export function universalIncPending(){
+    return {
+        type:'UNIVERSAL_INC_PENDING'
+    }
+}
+
+export function universalDecPending(){
+    return {
+        type:'UNIVERSAL_DEC_PENDING'
     }
 }
 

--- a/src/middleware/universal.js
+++ b/src/middleware/universal.js
@@ -8,15 +8,11 @@ function isPromise(val) {
 
 
 function keep(promise,dispatch, getState){
-    var pending = getState().router.pending;
-    pending++;
-    dispatch(actions.universalSetPeniding(pending));
 
+    dispatch(actions.universalIncPending());
     promise.then(function(data){
-        pending = getState().router.pending;
-        pending--;
         setTimeout(()=>{ //dont be mad at this! its seems dirty but it just makes my resolution of the promise happens after the user.
-            dispatch(actions.universalSetPeniding(pending));
+            dispatch(actions.universalDecPending());
         },0)
     });
 }

--- a/src/reducer/reducer.js
+++ b/src/reducer/reducer.js
@@ -1,6 +1,5 @@
 
 function router (state = {},action= {}){
-
     switch (action.type) {
 
         case 'PREVENT_NAVIGATION':
@@ -17,7 +16,6 @@ function router (state = {},action= {}){
             };
 
         case 'ALLOW_NAVIGATION':
-
             delete state.attemptedOnPrevent;
             return {
                 ...state,
@@ -26,23 +24,30 @@ function router (state = {},action= {}){
             };
 
         case 'ROUTER_NAVIGATION':
-
-
             var routerObj = action.router;
             state.previous = state.url;
-
             return {
                 ...state,
                 ...routerObj
             };
 
-
-        case 'UNIVERSAL_SET_PENDING':
+        case 'UNIVERSAL_RESET_PENDING':
             return {
                 ...state,
-                pending:action.val
+                pending: 0
             };
 
+        case 'UNIVERSAL_INC_PENDING':
+            return {
+                ...state,
+                pending:state.pending+1
+            };
+
+        case 'UNIVERSAL_DEC_PENDING':
+            return {
+                ...state,
+                pending:state.pending-1
+            };
 
         case 'UNIVERSAL_PROMISE_DONE':
             return {

--- a/src/redux-tiny-router/redux-tiny-router.js
+++ b/src/redux-tiny-router/redux-tiny-router.js
@@ -61,7 +61,7 @@ export function initUniversal (url,createStore,Layout,initialState){
             pending,
             html;
 
-        store.dispatch(actions.universalSetPeniding(0));
+        store.dispatch(actions.universalResetPending());
 
         var unsubscribe = store.subscribe(()=>{
             state = store.getState();


### PR DESCRIPTION
Hi! I'm building a project based on  [react-redux-tiny](https://github.com/Agamennon/react-redux-tiny), 
and I think 'pending' state is probably not correctly handled, please take a look:
https://github.com/Agamennon/redux-tiny-router/blob/master/src/middleware/universal.js#L16-L20

suppose action A and action B are dispatched and processed by `universal` middleware (both are promises), when A `dispatch(actions.universalSetPeniding(pending));` in `setTimeout` callback, A could be setting the `pending` corrupted by B.

Also I fixed some stuff and made redux-tiny-router work with server side data fetching, please take a look [here](https://github.com/FallenMax/redux-react-template)
