### PR TITLE
Fix state mutation in reducer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+node_modules/
+bin/

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "license": "MIT",
   "scripts": {
-      "build": "webpack --config webpack.config.js",
-      "postinstall": "npm run build"
+    "build": "webpack --config webpack.config.js",
+    "postinstall": "npm run build"
   },
   "dependencies": {
     "http-hash": "^2.0.0",
@@ -35,6 +35,7 @@
   "devDependencies": {
     "babel-loader": "^5.3.2",
     "babel-runtime": "^5.8.20",
-    "path": "^0.11.14"
+    "path": "^0.11.14",
+    "webpack": "^1.12.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "license": "MIT",
   "scripts": {
-      "build": "webpack",
+      "build": "webpack --config webpack.config.js",
       "postinstall": "npm run build"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "url": "https://github.com/Agamennon/redux-tiny-router.git"
   },
   "license": "MIT",
+  "scripts": {
+      "build": "webpack",
+      "postinstall": "npm run build"
+  },
   "dependencies": {
     "http-hash": "^2.0.0",
     "query-string": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "http-hash": "^2.0.0",
     "query-string": "^2.4.0",
     "react": "^0.13.3",
-    "redux": "^2.0.0"
+    "redux": "^2.0.0",
+    "webpack": "^1.12.2"
   },
   "devDependencies": {
     "babel-loader": "^5.3.2",
     "babel-runtime": "^5.8.20",
-    "path": "^0.11.14",
-    "webpack": "^1.12.2"
+    "path": "^0.11.14"
   }
 }

--- a/src/reducer/reducer.js
+++ b/src/reducer/reducer.js
@@ -29,11 +29,11 @@ function router (state = {},action= {}){
 
 
             var routerObj = action.router;
-            state.previous = state.url;
 
             return {
                 ...state,
-                ...routerObj
+                ...routerObj,
+                previous: state.url
             };
 
 
@@ -75,4 +75,3 @@ function router (state = {},action= {}){
 export default {
     router:{router}
 }
-

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,7 +37,7 @@ module.exports = {
     module: {
         loaders: [
             {
-                test: /\.jsx?$/,
+                test: /\.(jsx?|js)$/,
               //  loader:'babel?stage=0',
                loader:'babel?optional[]=runtime&stage=0',
          //       loader:'babel?optional[]=runtime&stage=0',
@@ -47,4 +47,3 @@ module.exports = {
         ]
     }
 };
-


### PR DESCRIPTION
This was logging a warning when paired with
`redux-immutable-state-invariant`. This also builds the file on
`postinstall` so npm link (and installing from a fork) works.

Also adds node_modules and bin to .gitignore since it seems like those shouldn't be checked in.
